### PR TITLE
Refactor into modular package with basic CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Notes
+
+## Next Session
+- Flesh out downloaders for additional datasets (equity and commodity swaps, EDGAR filing downloads).
+- Expand SQLite schema to store parsed records from NCEN/NPORT and link with CIK/LEI mappings.
+- Implement search functions across the stored swaps and filings to trace liability chains.
+- Integrate local LLM summarization for free-form filings to extract derivative information.
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# SECthingv2
-this bad boy scrapes every/any type of archive from the SEC in raw form, turning anyone into an archivist.
+# Gamecock
 
-install python 3.12.
-then from command line, simply go to the folder containing the script and type:
-python3 gamecockv1.py
+This project provides tools for downloading and analyzing swap data from CFTC archives and related SEC filings. A small command line interface enables looking up CIKs by ticker symbol and downloading daily swap archives.
 
-it will auto install the required modules, and query for which archives to download.
-almost everythings broken at the moment after that, but, AI is a very powerful tool on how to understand the filings inside the archives.
-explore, poke around in the, and look things up. 
-make learning great again :)
+## Usage
+
+Install Python 3.12 or newer and run:
+
+```bash
+python scripts/gamecock.py TICKER --download-cftc
+```
+
+The first run creates a `gamecock.db` SQLite database to track downloaded files. Additional modules and features will be added over time.
+

--- a/dev_progress.md
+++ b/dev_progress.md
@@ -1,0 +1,9 @@
+# Development Progress
+
+## Initial Refactor
+- Created package `gamecock` with modules for database, CLI, identifier lookup, downloaders, and parsers.
+- Implemented `ArchiveDownloader` base class and CFTC/EDGAR downloaders using it.
+- Added SQLite database helpers for recording downloaded files.
+- Added simple NCEN parser as example dataset parser.
+- Added command line interface supporting ticker lookup and a sample CFTC download action.
+- Added entry script `scripts/gamecock.py`.

--- a/gamecock/__init__.py
+++ b/gamecock/__init__.py
@@ -1,0 +1,2 @@
+"""Gamecock package"""
+

--- a/gamecock/cli.py
+++ b/gamecock/cli.py
@@ -1,0 +1,33 @@
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+from . import database, identifiers
+from .downloader.cftc import CFTCCreditDownloader
+
+
+DEFAULT_LOOKUP = Path('cik-lookup-data.txt')
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gamecock CLI")
+    parser.add_argument('ticker', nargs='?', help='Ticker symbol to search')
+    parser.add_argument('--lookup', type=Path, default=DEFAULT_LOOKUP, help='Path to cik lookup')
+    parser.add_argument('--download-cftc', action='store_true', help='Download CFTC credit archives for last day')
+    args = parser.parse_args()
+
+    database.init_db()
+
+    if args.ticker:
+        ciks = identifiers.find_ciks_by_ticker(args.ticker, args.lookup)
+        print(f'CIKs for {args.ticker}: {", ".join(ciks) if ciks else "none"}')
+
+    if args.download_cftc:
+        today = datetime.utcnow().date()
+        dl = CFTCCreditDownloader(Path('cftc_credit'), today, today)
+        dl.download()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/gamecock/database.py
+++ b/gamecock/database.py
@@ -1,0 +1,57 @@
+import sqlite3
+from pathlib import Path
+from datetime import datetime
+
+DB_NAME = "gamecock.db"
+
+def get_connection(db_path: Path = Path(DB_NAME)):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db(db_path: Path = Path(DB_NAME)):
+    conn = get_connection(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS files (
+            id INTEGER PRIMARY KEY,
+            url TEXT UNIQUE,
+            path TEXT,
+            size INTEGER,
+            downloaded_at TIMESTAMP
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS filings (
+            cik TEXT,
+            accession TEXT,
+            form TEXT,
+            filepath TEXT,
+            downloaded_at TIMESTAMP,
+            UNIQUE(cik, accession)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def record_file(url: str, path: Path, size: int, db_path: Path = Path(DB_NAME)):
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT OR IGNORE INTO files(url, path, size, downloaded_at) VALUES(?,?,?,?)",
+        (url, str(path), size, datetime.utcnow()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def file_exists(url: str, db_path: Path = Path(DB_NAME)) -> bool:
+    conn = get_connection(db_path)
+    cur = conn.execute("SELECT 1 FROM files WHERE url=?", (url,))
+    exists = cur.fetchone() is not None
+    conn.close()
+    return exists

--- a/gamecock/downloader/__init__.py
+++ b/gamecock/downloader/__init__.py
@@ -1,0 +1,2 @@
+"""Downloader package"""
+

--- a/gamecock/downloader/base.py
+++ b/gamecock/downloader/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import logging
+from pathlib import Path
+from abc import ABC, abstractmethod
+import requests
+
+from .. import database
+
+log = logging.getLogger(__name__)
+
+
+class ArchiveDownloader(ABC):
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    @abstractmethod
+    def generate_urls(self) -> list[str]:
+        ...
+
+    def download(self):
+        urls = self.generate_urls()
+        for url in urls:
+            filename = url.split('/')[-1]
+            target = self.output_dir / filename
+            if database.file_exists(url) and target.exists():
+                log.info("Skipping %s, already downloaded", url)
+                continue
+            log.info("Downloading %s", url)
+            try:
+                resp = requests.get(url, timeout=30)
+                resp.raise_for_status()
+            except Exception as e:
+                log.error("Failed %s: %s", url, e)
+                continue
+            target.write_bytes(resp.content)
+            database.record_file(url, target, len(resp.content))
+

--- a/gamecock/downloader/cftc.py
+++ b/gamecock/downloader/cftc.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+
+from .base import ArchiveDownloader
+
+
+class CFTCCreditDownloader(ArchiveDownloader):
+    BASE_URL = "https://kgc0418-tdw-data-0.s3.us-gov-west-1.amazonaws.com/s3fs-public/DCIO/DCIOSwapsData/credit/"
+
+    def __init__(self, output_dir: Path, start_date: datetime, end_date: datetime):
+        super().__init__(output_dir)
+        self.start_date = start_date
+        self.end_date = end_date
+
+    def generate_urls(self) -> List[str]:
+        urls = []
+        date = self.start_date
+        while date <= self.end_date:
+            name = f"{date.strftime('%Y-%m-%d')}.zip"
+            urls.append(self.BASE_URL + name)
+            date += timedelta(days=1)
+        return urls
+

--- a/gamecock/downloader/edgar.py
+++ b/gamecock/downloader/edgar.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .base import ArchiveDownloader
+
+
+class EdgarMasterDownloader(ArchiveDownloader):
+    BASE_URL = "https://www.sec.gov/Archives/edgar/daily-index/"
+
+    def __init__(self, output_dir: Path, year: int, quarter: int):
+        super().__init__(output_dir)
+        self.year = year
+        self.quarter = quarter
+
+    def generate_urls(self) -> List[str]:
+        url = f"{self.BASE_URL}{self.year}/QTR{self.quarter}/master.zip"
+        return [url]
+

--- a/gamecock/identifiers.py
+++ b/gamecock/identifiers.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import csv
+
+CACHED_LOOKUP = {}
+
+
+def load_cik_lookup(path: Path) -> dict:
+    if path in CACHED_LOOKUP:
+        return CACHED_LOOKUP[path]
+    lookup = {}
+    with path.open('r', encoding='utf-8', errors='ignore') as f:
+        reader = csv.reader(f, delimiter='|')
+        for line in reader:
+            if len(line) >= 2:
+                ticker = line[0].strip().upper()
+                cik = line[1].lstrip('0')
+                lookup.setdefault(ticker, set()).add(cik)
+    CACHED_LOOKUP[path] = lookup
+    return lookup
+
+
+def find_ciks_by_ticker(ticker: str, lookup_path: Path) -> list[str]:
+    lookup = load_cik_lookup(lookup_path)
+    return sorted(list(lookup.get(ticker.upper(), [])))

--- a/gamecock/parser/__init__.py
+++ b/gamecock/parser/__init__.py
@@ -1,0 +1,2 @@
+"""Parser package"""
+

--- a/gamecock/parser/ncen.py
+++ b/gamecock/parser/ncen.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import csv
+from typing import Generator, Dict
+
+
+def parse(zip_path: Path) -> Generator[Dict[str, str], None, None]:
+    """Yield records from an NCEN zip file."""
+    import zipfile
+
+    with zipfile.ZipFile(zip_path) as zf:
+        for name in zf.namelist():
+            if name.endswith("REGISTRANT.tsv"):
+                with zf.open(name) as f:
+                    reader = csv.DictReader(line.decode('utf-8') for line in f)
+                    for row in reader:
+                        yield row
+

--- a/scripts/gamecock.py
+++ b/scripts/gamecock.py
@@ -1,0 +1,5 @@
+from gamecock.cli import main
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- refactor code into new `gamecock` package with downloader, parser and database modules
- add simple command line interface and entry script
- store progress notes and next steps
- update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ca1ed4ab4832c9a106a22bfba88a8