### PR TITLE
Add equity/commodity downloaders and search utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
 # Agent Notes
 
+## Completed
+- Added downloaders for equity and commodity swaps and individual EDGAR filings.
+- Expanded SQLite schema with LEI mapping and tables for NCEN registrants and NPORT holdings.
+- Implemented basic search utility to find filings by LEI and exposed new CLI options.
+
 ## Next Session
-- Flesh out downloaders for additional datasets (equity and commodity swaps, EDGAR filing downloads).
-- Expand SQLite schema to store parsed records from NCEN/NPORT and link with CIK/LEI mappings.
-- Implement search functions across the stored swaps and filings to trace liability chains.
-- Integrate local LLM summarization for free-form filings to extract derivative information.
+- Parse NCEN and NPORT filings into the new tables.
+- Build queries that walk CIK/LEI links to trace liability chains across datasets.
+- Integrate local LLM summarization of narrative filings to extract derivative details.
 

--- a/README.md
+++ b/README.md
@@ -10,5 +10,13 @@ Install Python 3.12 or newer and run:
 python scripts/gamecock.py TICKER --download-cftc
 ```
 
+Additional options allow downloading equity or commodity swap archives, EDGAR filings, and tracing LEIs:
+
+```bash
+python scripts/gamecock.py --download-equity
+python scripts/gamecock.py --download-filing 0000320193 0000320193-24-000010
+python scripts/gamecock.py --trace-lei XXXXXXXXXXXX
+```
+
 The first run creates a `gamecock.db` SQLite database to track downloaded files. Additional modules and features will be added over time.
 

--- a/dev_progress.md
+++ b/dev_progress.md
@@ -7,3 +7,10 @@
 - Added simple NCEN parser as example dataset parser.
 - Added command line interface supporting ticker lookup and a sample CFTC download action.
 - Added entry script `scripts/gamecock.py`.
+
+## Expanded Data Support
+- Created downloaders for CFTC equity and commodity swaps.
+- Added downloader for individual EDGAR filings.
+- Implemented NPORT parser and expanded SQLite schema with LEI mappings and holding tables.
+- Added simple search utility to locate filings by LEI.
+- Extended CLI to expose new download and search functions.

--- a/gamecock/cli.py
+++ b/gamecock/cli.py
@@ -2,8 +2,13 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 
-from . import database, identifiers
-from .downloader.cftc import CFTCCreditDownloader
+from . import database, identifiers, search
+from .downloader.cftc import (
+    CFTCCreditDownloader,
+    CFTCEquityDownloader,
+    CFTCCommodityDownloader,
+)
+from .downloader.edgar import EdgarFilingDownloader
 
 
 DEFAULT_LOOKUP = Path('cik-lookup-data.txt')
@@ -14,6 +19,10 @@ def main():
     parser.add_argument('ticker', nargs='?', help='Ticker symbol to search')
     parser.add_argument('--lookup', type=Path, default=DEFAULT_LOOKUP, help='Path to cik lookup')
     parser.add_argument('--download-cftc', action='store_true', help='Download CFTC credit archives for last day')
+    parser.add_argument('--download-equity', action='store_true', help='Download CFTC equity archives for last day')
+    parser.add_argument('--download-commodity', action='store_true', help='Download CFTC commodity archives for last day')
+    parser.add_argument('--download-filing', nargs=2, metavar=('CIK', 'ACCESSION'), help='Download a specific EDGAR filing')
+    parser.add_argument('--trace-lei', help='Search filings associated with a LEI')
     args = parser.parse_args()
 
     database.init_db()
@@ -26,6 +35,25 @@ def main():
         today = datetime.utcnow().date()
         dl = CFTCCreditDownloader(Path('cftc_credit'), today, today)
         dl.download()
+
+    if args.download_equity:
+        today = datetime.utcnow().date()
+        dl = CFTCEquityDownloader(Path('cftc_equity'), today, today)
+        dl.download()
+
+    if args.download_commodity:
+        today = datetime.utcnow().date()
+        dl = CFTCCommodityDownloader(Path('cftc_commodity'), today, today)
+        dl.download()
+
+    if args.download_filing:
+        cik, accession = args.download_filing
+        dl = EdgarFilingDownloader(Path('edgar_filings'), cik, accession)
+        dl.download()
+
+    if args.trace_lei:
+        for filing in search.find_filings_by_lei(args.trace_lei):
+            print(filing)
 
 
 if __name__ == '__main__':

--- a/gamecock/database.py
+++ b/gamecock/database.py
@@ -35,6 +35,36 @@ def init_db(db_path: Path = Path(DB_NAME)):
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS cik_lei (
+            cik TEXT PRIMARY KEY,
+            lei TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ncen_registrant (
+            cik TEXT,
+            lei TEXT,
+            name TEXT,
+            accession TEXT,
+            UNIQUE(lei, accession)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nport_holding (
+            lei TEXT,
+            issuer TEXT,
+            cusip TEXT,
+            value REAL,
+            accession TEXT
+        )
+        """
+    )
     conn.commit()
     conn.close()
 
@@ -55,3 +85,42 @@ def file_exists(url: str, db_path: Path = Path(DB_NAME)) -> bool:
     exists = cur.fetchone() is not None
     conn.close()
     return exists
+
+
+def record_cik_lei(cik: str, lei: str, db_path: Path = Path(DB_NAME)):
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT OR REPLACE INTO cik_lei(cik, lei) VALUES(?, ?)",
+        (cik, lei),
+    )
+    conn.commit()
+    conn.close()
+
+
+def record_ncen_registrant(
+    cik: str, lei: str, name: str, accession: str, db_path: Path = Path(DB_NAME)
+):
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT OR IGNORE INTO ncen_registrant(cik, lei, name, accession) VALUES(?,?,?,?)",
+        (cik, lei, name, accession),
+    )
+    conn.commit()
+    conn.close()
+
+
+def record_nport_holding(
+    lei: str,
+    issuer: str,
+    cusip: str,
+    value: float,
+    accession: str,
+    db_path: Path = Path(DB_NAME),
+):
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT OR IGNORE INTO nport_holding(lei, issuer, cusip, value, accession) VALUES(?,?,?,?,?)",
+        (lei, issuer, cusip, value, accession),
+    )
+    conn.commit()
+    conn.close()

--- a/gamecock/downloader/cftc.py
+++ b/gamecock/downloader/cftc.py
@@ -22,3 +22,21 @@ class CFTCCreditDownloader(ArchiveDownloader):
             date += timedelta(days=1)
         return urls
 
+
+class CFTCEquityDownloader(CFTCCreditDownloader):
+    """Downloader for the equity swaps dataset."""
+
+    BASE_URL = (
+        "https://kgc0418-tdw-data-0.s3.us-gov-west-1.amazonaws.com/s3fs-public/"
+        "DCIO/DCIOSwapsData/equity/"
+    )
+
+
+class CFTCCommodityDownloader(CFTCCreditDownloader):
+    """Downloader for the commodity swaps dataset."""
+
+    BASE_URL = (
+        "https://kgc0418-tdw-data-0.s3.us-gov-west-1.amazonaws.com/s3fs-public/"
+        "DCIO/DCIOSwapsData/commodity/"
+    )
+

--- a/gamecock/downloader/edgar.py
+++ b/gamecock/downloader/edgar.py
@@ -17,3 +17,18 @@ class EdgarMasterDownloader(ArchiveDownloader):
         url = f"{self.BASE_URL}{self.year}/QTR{self.quarter}/master.zip"
         return [url]
 
+
+class EdgarFilingDownloader(ArchiveDownloader):
+    """Download a single EDGAR filing given CIK and accession."""
+
+    BASE_URL = "https://www.sec.gov/Archives/"
+
+    def __init__(self, output_dir: Path, cik: str, accession: str):
+        super().__init__(output_dir)
+        self.cik = cik.lstrip("0")
+        self.accession = accession.replace("-", "")
+
+    def generate_urls(self) -> List[str]:
+        path = f"edgar/data/{self.cik}/{self.accession}/{self.accession}-index.html"
+        return [self.BASE_URL + path]
+

--- a/gamecock/parser/__init__.py
+++ b/gamecock/parser/__init__.py
@@ -1,2 +1,6 @@
 """Parser package"""
 
+from . import ncen, nport
+
+__all__ = ["ncen", "nport"]
+

--- a/gamecock/parser/nport.py
+++ b/gamecock/parser/nport.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import csv
+from typing import Generator, Dict
+
+
+def parse(zip_path: Path) -> Generator[Dict[str, str], None, None]:
+    """Yield holding records from an NPORT zip file."""
+    import zipfile
+
+    with zipfile.ZipFile(zip_path) as zf:
+        for name in zf.namelist():
+            if name.endswith("HOLDINGS.tsv"):
+                with zf.open(name) as f:
+                    reader = csv.DictReader(line.decode('utf-8') for line in f)
+                    for row in reader:
+                        yield row

--- a/gamecock/search.py
+++ b/gamecock/search.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import List
+
+from .database import get_connection, DB_NAME
+
+
+def find_filings_by_lei(lei: str, db_path: Path = Path(DB_NAME)) -> List[dict]:
+    """Return filings associated with the given LEI."""
+    conn = get_connection(db_path)
+    cur = conn.execute(
+        """
+        SELECT f.cik, f.accession, f.form, f.filepath
+        FROM filings f
+        JOIN ncen_registrant n ON f.cik = n.cik
+        WHERE n.lei = ?
+        """,
+        (lei,),
+    )
+    rows = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    return rows


### PR DESCRIPTION
## Summary
- create CFTC equity and commodity downloaders
- add EDGAR filing downloader
- expand SQLite schema with LEI tables
- provide NPORT parser and search functions
- extend CLI and README
- document progress and update agent notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685caae0e438832cbbd8f7e5f97e1e9b